### PR TITLE
Adding morse code 'Error' (8 dits) as ctrl+backspace

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -231,6 +231,7 @@ static void dida_parse(void) {
 		uint8_t send_code = morse_code_parse(valid_cache, dida_depth);
 		if(send_code == KEYCODE_ERROR) {
 			char_send(KEY_BACKSPACE, KEY_MOD_LCTRL);
+			char_send(KEY_NONE, 0);
 			dida_idle_timer = 0;
 		} else if(send_code == KEYCODE_SOS) {
 			uint8_t mod;

--- a/src/main.c
+++ b/src/main.c
@@ -229,7 +229,10 @@ static void dida_parse(void) {
 			}
 		}
 		uint8_t send_code = morse_code_parse(valid_cache, dida_depth);
-		if(send_code == 0xFE) {
+		if(send_code == KEYCODE_ERROR) {
+			char_send(KEY_BACKSPACE, KEY_MOD_LCTRL);
+			dida_idle_timer = 0;
+		} else if(send_code == KEYCODE_SOS) {
 			uint8_t mod;
 			if(is_caps_on) {
 				mod = KEY_MOD_LSHIFT;

--- a/src/module/morse_code.h
+++ b/src/module/morse_code.h
@@ -5,6 +5,10 @@
 #include <stdint.h>
 #include "usb_hid_keys.h"
 
+#define KEYCODE_ERROR          0xFD
+#define KEYCODE_SOS            0xFE
+#define KEYCODE_UNDEFINED      0xFF
+
 typedef struct morse_code {
 	const struct morse_code const* dit;
 	const struct morse_code const* dah;
@@ -20,10 +24,16 @@ const sMC node_null = {
 	0xFF
 };
 
-NODEF(SOS, 0xFE);
+// custom key: sos
+NODEF(SOS, KEYCODE_SOS);
 NODE(3100, 0xFF, SOS, null);
 NODE(310, 0xFF, 3100, null);
 NODE(31, 0xFF, 310, null);
+
+// custom key: error
+NODEF(error, KEYCODE_ERROR);
+NODE(dit7, 0xFF, error, null);
+NODE(dit6, 0xFF, dit7, null);
 
 // dit
 NODEF(apostrophe, KEY_APOSTROPHE);
@@ -37,7 +47,7 @@ NODEF(2, KEY_2);
 NODE(v0, 0xFF,  null,  end);
 NODE(3, KEY_3, null, 31);
 NODEF(4, KEY_4);
-NODEF(5, KEY_5);
+NODE(5, KEY_5, dit6, null);
 NODEF(p, KEY_P);
 NODE(j, KEY_J, null, 1);
 NODE(r1, 0xFF, r10, null);


### PR DESCRIPTION
reference to: https://en.wikipedia.org/wiki/Morse_code#Letters,_numbers,_punctuation,_prosigns_for_Morse_code_and_non-Latin_variants

Adding morse code 'Error' (8 dits) as ctrl+backspace to delete words that previously inputted.